### PR TITLE
fix: revert zod to v3 for compatibility

### DIFF
--- a/packages/conform/package.json
+++ b/packages/conform/package.json
@@ -76,7 +76,7 @@
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.1",
     "minimatch": "^10.1.1",
-    "zod": "^4.3.5",
+    "zod": "^3.24.1",
     "zod-to-json-schema": "^3.25.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,7 @@ importers:
         version: 2.2.5
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.3
-        version: 1.25.3(hono@4.11.5)(zod@4.3.6)
+        version: 1.25.3(hono@4.11.5)(zod@3.25.76)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -99,11 +99,11 @@ importers:
         specifier: ^10.1.1
         version: 10.1.1
       zod:
-        specifier: ^4.3.5
-        version: 4.3.6
+        specifier: ^3.24.1
+        version: 3.25.76
       zod-to-json-schema:
         specifier: ^3.25.1
-        version: 3.25.1(zod@4.3.6)
+        version: 3.25.1(zod@3.25.76)
     devDependencies:
       '@types/js-yaml':
         specifier: ^4.0.9
@@ -2719,6 +2719,9 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -4272,7 +4275,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/sdk@1.25.3(hono@4.11.5)(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.25.3(hono@4.11.5)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.5)
       ajv: 8.17.1
@@ -4288,8 +4291,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - hono
       - supports-color
@@ -6251,8 +6254,10 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
-  zod-to-json-schema@3.25.1(zod@4.3.6):
+  zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:
-      zod: 4.3.6
+      zod: 3.25.76
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}


### PR DESCRIPTION
## Summary
- Revert zod from ^4.3.5 to ^3.24.1
- Zod v4 has breaking API changes that are incompatible with current code

The previous release workflow failed because zod v4 changed:
- `ZodEffects` is no longer exported the same way
- `error.errors` is now `error.issues`
- `ZodObject` assignment compatibility changed

## Test plan
- [x] Build passes locally
- [x] Typecheck passes locally
- [ ] CI should pass
- [ ] Release workflow should publish packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)