### PR TITLE
feat: add process.repo branch protection config

### DIFF
--- a/standards.toml
+++ b/standards.toml
@@ -25,3 +25,16 @@ enabled = true
 types = ["feat", "fix", "chore", "docs", "refactor", "test", "style", "perf", "ci", "build"]
 require_scope = false
 max_subject_length = 100
+
+# =============================================================================
+# Process - Repository Settings
+# =============================================================================
+
+[process.repo]
+enabled = true
+require_branch_protection = true
+
+[process.repo.ruleset]
+branch = "main"
+enforcement = "active"
+required_reviews = 0


### PR DESCRIPTION
## Summary
- Adds `process.repo` configuration to `standards.toml` requiring a GitHub Ruleset on `main` with active enforcement
- No required reviews (solo developer workflow)
- Enables `conform process check` to verify branch protection and `conform process sync --apply` to create rulesets

## Test plan
- [ ] `conform process check` detects missing ruleset
- [ ] `conform process sync --apply` creates the ruleset
- [ ] `gh api repos/chrismlittle123/standards-kit/rulesets` returns active ruleset

🤖 Generated with [Claude Code](https://claude.com/claude-code)