### PR TITLE
fix: include all required parameters in pull_request ruleset rule

### DIFF
--- a/packages/conform/src/process/sync/applier.ts
+++ b/packages/conform/src/process/sync/applier.ts
@@ -145,15 +145,11 @@ function buildPullRequestRule(
   return {
     type: "pull_request",
     parameters: {
-      ...(desired.required_reviews !== undefined && {
-        required_approving_review_count: desired.required_reviews,
-      }),
-      ...(desired.dismiss_stale_reviews !== undefined && {
-        dismiss_stale_reviews_on_push: desired.dismiss_stale_reviews,
-      }),
-      ...(desired.require_code_owner_reviews !== undefined && {
-        require_code_owner_review: desired.require_code_owner_reviews,
-      }),
+      required_approving_review_count: desired.required_reviews ?? 0,
+      dismiss_stale_reviews_on_push: desired.dismiss_stale_reviews ?? false,
+      require_code_owner_review: desired.require_code_owner_reviews ?? false,
+      require_last_push_approval: false,
+      required_review_thread_resolution: false,
     },
   };
 }


### PR DESCRIPTION
## Summary
- Fixed `buildPullRequestRule` in the sync applier to include all required GitHub API parameters
- GitHub API requires `require_last_push_approval` and `required_review_thread_resolution` in pull_request rules
- Without these, the API returns HTTP 422 "Invalid property /rules/0: data matches no possible input"

## Test plan
- [ ] `conform process sync --apply` successfully creates a ruleset (previously failed with 422)
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)