### PR TITLE
fix: skip auto-generated commits in audit and fetch full rulesets in sync

### DIFF
--- a/packages/conform/tests/unit/process/tools/commits.test.ts
+++ b/packages/conform/tests/unit/process/tools/commits.test.ts
@@ -22,6 +22,24 @@ describe("CommitsRunner", () => {
     expect(runner.toolId).toBe("commits");
   });
 
+  describe("auto-generated commits", () => {
+    it.each([
+      ["Merge pull request #1 from owner/branch", "merge"],
+      ["Merge branch 'feature' into main", "merge"],
+      ["Revert \"feat: add feature\"", "revert"],
+      ["fixup! feat: add feature", "fixup"],
+      ["squash! feat: add feature", "squash"],
+      ["amend! feat: add feature", "amend"],
+    ])("skips auto-generated commit: %s (%s)", async (subject) => {
+      runner.setConfig({ enabled: true, types: ["feat", "fix"] });
+      mockedExeca.mockResolvedValue({ stdout: subject } as never);
+
+      const result = await runner.run("/root");
+      expect(result.skipped).toBe(true);
+      expect(result.skipReason).toContain("Auto-generated commit message");
+    });
+  });
+
   describe("skip cases", () => {
     it("skips when no pattern or types configured", async () => {
       runner.setConfig({ enabled: true });


### PR DESCRIPTION
## Summary
- **#28**: `CommitsRunner` now skips merge, revert, fixup, squash, and amend commits during `conform audit`, preventing false failures in CI when GitHub creates merge commits
- **#29**: Sync fetcher now fetches individual rulesets by ID after listing, since the GitHub list endpoint (`GET /repos/{owner}/{repo}/rulesets`) omits `conditions` and `rules` fields needed for branch matching and rule parsing

## Test plan
- [x] All 1273 existing tests pass
- [x] New tests for auto-generated commit skip patterns (merge, revert, fixup, squash, amend)
- [x] New tests for two-step fetch pattern (list then individual fetch)
- [x] New test for fallback when individual fetch fails
- [x] Build, typecheck, and lint pass

Closes #28, closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)